### PR TITLE
changes 'with' to 'without'

### DIFF
--- a/team/index.md
+++ b/team/index.md
@@ -9,7 +9,7 @@ image:
   creditlink:
 ---
 
-Stan is a team effort that could not be carried out with external
+Stan is a team effort that could not be carried out without external
   grant funding.
 
 Development Team


### PR DESCRIPTION
Changes 

>"Stan is a team effort that could not be carried out with external grant funding."

to 

>"Stan is a team effort that could not be carried out without external grant funding."

I might just be sleepy, but it should be *without*, right?