### PR TITLE
fix issue #40: /about/team never loads in Chrome-based browsers

### DIFF
--- a/about/team/index.md
+++ b/about/team/index.md
@@ -76,7 +76,7 @@ volunteer developers.
 
 Developers who have made important contributions in the past, but are no longer contributing actively:
 
-<ul style="columns:2">
+<ul style="columns:2" style="clear:both">
 {% for member in site.data.alumni_developers %}
 
 
@@ -135,3 +135,7 @@ Developers who have made important contributions in the past, but are no longer 
 
 For more info on how join the the development team, read about
 [how to contribute to Stan](/development/).
+
+<style>
+body { line-height: normal; }
+</style>


### PR DESCRIPTION
Fix issue #40. After a lot of debugging, I was finally able to fix it! Somehow Chromium didn't liked body line-height: normal property + float on bio images. Also, needed to clear both on ul of ex-developers section (both fixes are needed in order to fix Chromium).

Just fells nostalgic about the bad old days of losing my mind looking for ways to patch trusty IE 6...

As a bonus this also fixes a split column bug: right using Firefox, Brian Lau name is showing up at the end of the first column and his photo at the beginning of the second column. This should fix it.