### PR TITLE
Add ScalaStan link to their github.

### DIFF
--- a/users/interfaces/index.md
+++ b/users/interfaces/index.md
@@ -38,6 +38,9 @@ through interfaces into many popular computing environments.
 * [MathematicaStan](mathematica-stan.html)
   <span class="note">(Mathematica)</span>
 
+* [ScalaStan](https://github.com/cibotech/ScalaStan)
+  <span class="note">(Scala)</span>
+
 Programs written in the Stan modeling language are portable
 across interfaces.
 


### PR DESCRIPTION
Is it okay that we don't have a separate page for each piece of ScalaStan? I figure linking to a homepage makes a lot more sense than having a page for each interface if their homepage is somewhere else.