### PR TITLE
Feature/nav reorg

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,19 +1,17 @@
 # Site navigation links
 
-- title: About
+- title: Installation
+  url: /users/interfaces/
+
+- title: Documentation
+  url: /users/documentation/
+
+- title: Community
+  url: /community/  
+
+- title: About Us
   url: /about/
 
-- title: Users
-  url: /users/
-
-- title: Developers
-  url: /developers/
-  
-- title: Events
-  url: /events/  
-
-- title: Shop
-  url: /shop/
-
-- title: Support
+- title: Your Support
   url: /support/
+

--- a/about/index.md
+++ b/about/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: About
+title: About Us
 excerpt: ""
 modified:
 image:
@@ -8,9 +8,6 @@ image:
   credit:
   creditlink:
 ---
-
-{:.center-txt}
-who we are
 
 Stan is freedom-respecting, open-source software <span
 class="note">(new BSD core, some interfaces GPLv3)</span>

--- a/community/index.md
+++ b/community/index.md
@@ -1,0 +1,39 @@
+---
+layout: page
+title: Stan Community
+excerpt: ""
+modified:
+image:
+  feature: feature/wide_ensemble.png
+  credit:
+  creditlink:
+---
+
+# Developers
+
+[Open source software development](/developers)
+
+
+# Events
+
+[Past meetups, talks &amp; courses](/events)
+
+# Contact Us
+
+If you're looking for help with installing Stan, coding and debugging Stan
+programs, Bayesian inference in general, or just want to let everyone know
+what you're doing with Stan then please post to the Stan Forums,
+
+* <p><a href="http://discourse.mc-stan.org/">Stan Forums</a>
+<span class="note">(Discourse)</span></p>
+
+Everyone who joins the forum has posting privileges.  We love hearing about
+application of Stan and we try very hard to be as helpful as possible, so
+please don't be shy to introduce yourself, share your work, or ask a question!
+
+If you think you have found a bug in Stan or would like to request new features
+then you can also post an issue to the appropriate interface-specific issue
+tracker.  For more information see
+
+* <p><a href="/users/issues/index.html">Submitting an Issue</a></p>
+

--- a/developers/index.md
+++ b/developers/index.md
@@ -10,9 +10,6 @@ image:
 redirect_from: "/development/"
 ---
 
-{:.center-txt}
-software development with Stan
-
 Stan is open source because we want your contributions to help make
 Stan's code and documentation better.
 

--- a/events/index.md
+++ b/events/index.md
@@ -9,9 +9,6 @@ image:
   creditlink:
 ---
 
-{:.center-txt}
-meetups, talks &amp; courses
-
 # [StanCon 2018 Helsinki, Finland 29-31 August](/events/stancon2018Helsinki)
 
 

--- a/shop/index.md
+++ b/shop/index.md
@@ -9,10 +9,6 @@ image:
   creditlink:
 ---
 
-{:.center-txt}
-for your Stan swag
-
-
 If you're looking to infer in style, stop by one of our shops for Stan
 t-shirts and mugs.
 

--- a/support/index.md
+++ b/support/index.md
@@ -9,9 +9,6 @@ image:
   creditlink:
 ---
 
-{:.center-txt}
-help support Stan's future
-
 # Contribute to the Stan Project
 
 Stan is now linked to [NumFOCUS](http://numfocus.org/), a
@@ -37,3 +34,7 @@ we also give a lot of free and open help through the
 organization is helping to make this state-of-the-art Bayesian data
 analysis program even better. You’re pushing forward the frontiers of
 science and helping your own work as well as others'.
+
+# Stan goods for good
+
+[Stan t-shirts and mugs](/shop)


### PR DESCRIPTION
## Summary

Changed navigation titles per discussion with Breck and Matthijs.

To test this locally, check out this branch then run:

`bundle exec jekyll serve`

website will be available at `http://localhost:4000`

(assuming that you have the jekyll tools installed)
