### PR TITLE
Add a Stan for Epidemiology page

### DIFF
--- a/users/documentation/index.md
+++ b/users/documentation/index.md
@@ -101,7 +101,11 @@ specific fields.
   <a href="https://stanecology.github.io/">Stan for Ecology</a>
   &nbsp; <span class="note">(GitHub)</span>
   </p>
-
+  
+* <p>
+  <a href="https://epidemiology-stan.github.io/">Stan for Epidemiology</a>
+  &nbsp; <span class="note">(GitHub)</span>
+  </p>
 
 # The Stan Forums
 


### PR DESCRIPTION
Add a Stan for Epidemiology page to the Specialized Field Guides section, following the discussion here: https://discourse.mc-stan.org/t/stan-epidemiology-page/15176