### PR TITLE
Adding link to YouTube channel

### DIFF
--- a/_data/developers.yml
+++ b/_data/developers.yml
@@ -150,7 +150,7 @@
 - name: Imad Ali
   affiliation: PlayStation
   web: http://imadali.net
-  email: imad.ali@columbia.edu
+  email: imadmali@gmail.com
   linkedin: https://www.linkedin.com/in/imadmali
   github: imadmali
   avatar: imad_ali.jpg
@@ -294,7 +294,7 @@
   github: mgorinova
   linkedin: https://www.linkedin.com/in/mariagorinova/
   avatar: maria_gorinova.jpeg
-  
+
 - name: Duco Veen
   affiliation: Utrecht University
   web: http://ducoveen.com

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,5 +13,6 @@
 	{% if site.owner.tumblr %}<a href="http://{{ site.owner.tumblr }}.tumblr.com" title="{{ site.owner.name}} on Tumblr" target="_blank"><i class="fa fa-tumblr-square fa-2x"></i></a>{% endif %}
   {% if site.owner.pinterest %}<a href="https://www.pinterest.com/{{ site.owner.pinterest }}/" title="{{ site.owner.name}} on Pinterest" target="_blank"><i class="fa fa-pinterest fa-2x"></i></a>{% endif %}
 	{% if site.owner.weibo %}<a href="https://www.weibo.com/u/{{ site.owner.weibo }}/" title="{{ site.owner.name}} on Weibo" target="_blank"><i class="fa fa-weibo fa-2x"></i></a>{% endif %}
+	<a href="https://www.youtube.com/channel/UCwgN5srGpBH4M-Zc2cAluOA" title="YouTube Link"><i class="fa fa-youtube-square fa-2x"></i></a>
   <a href="{{ site.url }}/feed.xml" title="Atom/RSS feed"><i class="fa fa-rss-square fa-2x"></i></a>
 </div><!-- /.social-icons -->

--- a/about/index.md
+++ b/about/index.md
@@ -51,7 +51,7 @@ please email <board@mc-stan.org>.
 
 The current SGB members are:
 
-* Imad Ali <span class="note">(Playstation)</span>
+* Imad Ali <span class="note">(PlayStation)</span>
 * Leah Comment <span class="note">(Foundation Medicine Inc.)</span>
 * Jonah Gabry <span class="note">(Columbia University)</span>
 * Bill Gillespie <span class="note">(Metrum LLC)</span>


### PR DESCRIPTION
It doesn't look like the YouTube channel is linked anywhere on the site. I'm adding a link via a Font Awesome icon in the footer. For some reason the icons don't render when I build/serve the site locally, but they should work when it gets hosted on GitHub 🤞 (Idk if others who have worked with the site experienced that issue.)