### PR TITLE
fix shop link

### DIFF
--- a/shop/index.md
+++ b/shop/index.md
@@ -12,10 +12,10 @@ image:
 If you're looking to infer in style, stop by one of our shops for Stan
 t-shirts and mugs.
 
-* [Stan Shop [US]](http://mc-stan.spreadshirt.com/)
+* [Stan Shop [US]](https://shop.spreadshirt.com/mc-stan/)
   &nbsp; <span class="note">(Spreadshirt US)</span>
 
-* [Stan Shop [UK]](http://mc-stan.spreadshirt.co.uk/)
+* [Stan Shop [UK]](https://shop.spreadshirt.co.uk/mc-stan/)
   &nbsp; <span class="note">(Spreadshirt UK)</span>
 
 Don't hesitate to [let us know](/community/) if there are other Stan


### PR DESCRIPTION
Fix mc-stan shop link due to website pattern change. See https://discourse.mc-stan.org/t/merch-store-links-broken/21332.
