### PR TITLE
updating slack link to be the invite link

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -24,7 +24,7 @@ applications of Stan and we try very hard to be as helpful as possible, so
 please don't be shy to introduce yourself, share your work, or ask a question!
 
 There are also discussions happening over on Slack.
-All are welcome to join Slack at [mc-stan.slack.com](https://mc-stan.slack.com/).
+All are welcome to join Slack at [mc-stan.slack.com](https://join.slack.com/t/mc-stan/shared_invite/zt-1le4ebi4m-UMtiOkJb4gcS16qz2wIYCw).
 
 #  Bug Reports, Feature Requests
 


### PR DESCRIPTION
The slack link will now take you to the Slack invite link.