### PR TITLE
Add call for StanCon2023 and link to code of conduct.

### DIFF
--- a/events/stancon2023/index.md
+++ b/events/stancon2023/index.md
@@ -18,9 +18,11 @@ image:
 - [**Sponsors**](#sponsors)
 - [**Invited speakers**](#speakers)
 - [**Tutorials**](#tutorials)
+- [**Call for proposals**](#call)
 - [**Schedules**](#schedules)
 - [**Registration**](#registration)
 - [**Organizers**](#organizers)
+- [**Code of conduct**](#conduct)
 
 
 ------
@@ -44,6 +46,54 @@ image:
 **Synopsis:** coming soon.
 
 More tutorials coming soon.
+
+# [Call for proposals](#call)
+
+We invite participants to submit proposals for contributed talks, thematic sessions, posters, and tutorials.
+
+We are interested in a broad range of topics relevant to the Stan community, including:
+
+* Applications of Bayesian statistics using Stan in all domains
+* Software development to support or complement the Stan ecosystem
+* Methods for Bayesian modeling, relevant to a broad range of users
+* Theoretical insights on common Bayesian methods and models
+* Visualization techniques
+* Tools for teaching Bayesian modeling
+
+Keep in mind that StanCon brings together a diverse audience. Material which focuses on an application should introduce the problem to non-field experts; theoretical insights should be linked to problems modelers are working on, etc.
+
+## [Call for contributed talks](#call-talks)
+
+Talks are 15 minutes long, with an additional 5 minutes dedicated to questions.
+
+To submit a proposal for a contributed talk, submit a form via https://forms.gle/4fbNbd4p32MFPR219 by March 15th.
+
+## [Call for thematic sessions](#call-sessions)
+
+Thematic sessions are an opportunity to dive deeper into a topic and comprise three talks (15 + 5 minutes each), with an additional 10 minutes which can be used for a panel discussion. Thematic sessions may be run in parallel.
+
+To submit a proposal for a contributed talk, submit a form via https://forms.gle/HcfZPS3jMb8HGqsY8 by March 15th.
+
+## [Call for posters](#call-posters)
+
+We invite participants to submit abstracts for posters. These abstracts will be reviewed by the StanCon scientific committee. Accepted posters will be displayed in a dedicated room during the conference. In addition, an online version of the poster will be available. We encourage authors to share code with which the results and figures in the poster can be reproduced.
+
+Posters should be 24in x 48in.
+
+If the poster summarizes work presented in a longer document (e.g. a paper, a doc), please reference this document.
+
+An example poster from StanCon 2018 can be found [here](https://www.metrumrg.com/wp-content/uploads/2018/09/stan_pde_poster.pdf).
+
+To submit an abstract, submit a form via https://forms.gle/rm2a6KFfhXJ5CyL67 by March 22nd.
+
+## [Call for tutorials](#call-tutorials)
+
+Tutorials are an opportunity to do an in-depth exploration of a particular topic and may focus on a class of models, certain features in the Stan language, or a new package in the broader Stan ecosystem. Tutorials typically include hands-on exercises, which participants can perform on their own computers.
+
+Tutorials may comprise a single session of 2 or 3 hours (half-a-day) or two sessions of 2 or 3 hours each (full day).
+
+To submit a proposal for a tutorial, submit a form via https://forms.gle/tgGmaSrQM7yTmHMA7 by March 15th.
+
 
 # [Sponsors](#sponsors)
 We would like to thank our sponsors who both support conference costs, scholarships, and Stan as a whole. If you’re interested in sponsoring StanCon, please email [stancon2023@mc-stan.org](mailto:stancon2023@mc-stan.org).
@@ -98,9 +148,6 @@ $299(student) | $449(academic) | $599(industry)
 ## Regular admission (After March 31, 2023)
 Coming soon.
 
-# [Contact](#contact)
-
-
 
 
 # [Organizers](#organizers)
@@ -111,3 +158,9 @@ Coming soon.
 - Yi Zhang (Sage Therapeutics, Inc)
 
 Contact us at [stancon2023@mc-stan.org](mailto:stancon2023@mc-stan.org).
+
+# [Code of conduct](#conduct)
+
+Participants are expected to abide by the [Stan code of conduct](https://discourse.mc-stan.org/t/announcing-our-new-stan-code-of-conduct/23764).
+
+


### PR DESCRIPTION

Add call for proposals for StanCon 2023 and link to code of conduct.
