### PR TITLE
fix broken links for interfaces

### DIFF
--- a/users/interfaces/cmdstan.md
+++ b/users/interfaces/cmdstan.md
@@ -39,7 +39,7 @@ CmdStan User’s Guide
 Stan's modeling language documentation is platform independent.
 
 * <p>
-  <a href="/documentation/">Stan Documentation</a>
+  <a href="/users/documentation/">Stan Documentation</a>
   </p>
 
 

--- a/users/interfaces/cmdstan.md.bak
+++ b/users/interfaces/cmdstan.md.bak
@@ -39,7 +39,7 @@ CmdStan User’s Guide
 Stan's modeling language documentation is platform independent.
 
 * <p>
-  <a href="/documentation/">Stan Documentation</a>
+  <a href="/users/documentation/">Stan Documentation</a>
   </p>
 
 

--- a/users/interfaces/julia-stan.md
+++ b/users/interfaces/julia-stan.md
@@ -35,7 +35,7 @@ Stan.jl's example-based documentation is also on its GitHub page.
 Stan's modeling language documentation is platform independent.
 
 * <p>
-  <a href="/documentation/">Stan Documentation</a>
+  <a href="/users/documentation/">Stan Documentation</a>
   </p>
 
 

--- a/users/interfaces/mathematica-stan.md
+++ b/users/interfaces/mathematica-stan.md
@@ -36,7 +36,7 @@ There is a REAMDE file:
 Stan's modeling language documentation is platform independent.
 
 * <p>
-  <a href="/documentation/">Stan Documentation</a>
+  <a href="/users/documentation/">Stan Documentation</a>
   </p>
 
 

--- a/users/interfaces/matlab-stan.md
+++ b/users/interfaces/matlab-stan.md
@@ -38,7 +38,7 @@ MatlabStan's documentation is also on the wiki.
 Stan's modeling language documentation is platform independent.
 
 * <p>
-  <a href="/documentation/">Stan Documentation</a>
+  <a href="/users/documentation/">Stan Documentation</a>
   </p>
 
 

--- a/users/interfaces/pystan.md
+++ b/users/interfaces/pystan.md
@@ -37,7 +37,7 @@ PyStan's API documentation is available from readthedocs.org.
 Stan's modeling language documentation is platform independent.
 
 * <p>
-  <a href="/documentation/">Stan Documentation</a>
+  <a href="/users/documentation/">Stan Documentation</a>
   </p>
 
 

--- a/users/interfaces/rstan.md
+++ b/users/interfaces/rstan.md
@@ -43,7 +43,7 @@ network.
 Stan's modeling language documentation is platform independent.
 
 * <p>
-  <a href="/documentation/">Stan Documentation</a>
+  <a href="/users/documentation/">Stan Documentation</a>
   </p>
 
 

--- a/users/interfaces/stata-stan.md
+++ b/users/interfaces/stata-stan.md
@@ -39,7 +39,7 @@ There are Stata-specifc examples in the file
 Stan's modeling language documentation is platform independent.
 
 * <p>
-  <a href="/documentation/">Stan Documentation</a>
+  <a href="/users/documentation/">Stan Documentation</a>
   </p>
 
 


### PR DESCRIPTION
so currently when you open documentation through an interface webpage, for example julia-stan (that's when I encountered this) https://mc-stan.org/users/interfaces/julia-stan then `Stan Documentation` there redirects you to `https://mc-stan.org/documentation/` instead of `https://mc-stan.org/users/documentation/`. I imagine one of the other possible fixes is having `/documentation/index.md` (currently `/documentation` does *not* have an `index.md` page, which can correctly redirect to `/users/documentation/index.md`.

What currently happens when you try to go to documentation is, downloading `index.md.bak`

Not sure if this is the correct fix, so treat this as an issue/fix!