### PR TITLE
Add code example on landing page

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,68 @@
+/* custom CSS only for the home page */
+/* all other CSS is shared with docs and in the quarto-config submodule */
+
+
+
+.content-block {
+    padding-top: 20px;
+    padding-bottom: 10px;
+    margin-left: 30px;
+    margin-right: 30px;
+  }
+
+  @media (min-width: 900px) {
+    .content-block {
+      margin-left: 50px;
+      margin-right: 50px;
+    }
+  }
+
+  @media (min-width: 1200px) {
+    .content-block {
+      max-width: 1100px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+
+  .hero-banner {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    color: var(--stan-hero);
+    background-color: var(--stan-hero-bg);
+    border: 10px solid var(--stan-secondary);
+  }
+
+  .hero-banner h1 {
+    font-size: 2.5rem;
+    margin-top: 1rem;
+    text-align: center;
+  }
+
+  .hero-banner .content-block {
+    padding-top: 0;
+  }
+
+  .hero-code {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-bottom: 1rem;
+    padding-top: 1rem;
+  }
+
+  .hero-code pre,
+  .hero-code code {
+    color: var(--bs-body-color);
+    padding: 0.25em;
+  }
+
+  .hero-code .code-with-filename-file {
+    border: 1px solid rgba(233, 236, 239, 0.2);
+    background-color: var(--stan-secondary);
+  }
+  .hero-code .code-with-filename-file pre {
+    background-color: inherit;
+    color: var(--stan-hero);
+  }

--- a/index.qmd
+++ b/index.qmd
@@ -11,7 +11,8 @@ aliases:
  - events/index.html
  - users/index.html
 
-
+css: index.css
+code-copy: false
 ---
 
 
@@ -20,7 +21,8 @@ aliases:
 
 # Stan: Software for Bayesian Data&nbsp;Analysis
 
-::::: {.hero-text}
+::::: {.hero-text .grid}
+:::::: {.g-col-12 .g-col-md-8}
 
 ### Bayesian Modeling
 
@@ -35,7 +37,26 @@ Stan's probabilistic programming language is suitable for a wide range of applic
 Interfaces for Python, Julia, R, and the Unix shell make it easy to use Stan in any programming environment,
 on  laptops, clusters, or in the cloud.  A rich ecosystem of tools for validation and visualization support
 decision-making and communication.
+::::::
 
+:::::: {.g-col-12 .g-col-md-4 .hero-code}
+
+```{.stan filename="bernoulli.stan"}
+data {
+  int<lower=0> N;
+  array[N] int<lower=0, upper=1> y;
+}
+parameters {
+  real<lower=0, upper=1> theta;
+}
+model {
+  // uniform prior on interval 0,1
+  theta ~ beta(1, 1);
+  y ~ bernoulli(theta);
+}
+```
+
+::::::
 
 :::::
 ::::: {.hero-buttons style="position: relative; display: flex; justify-content: center;"}


### PR DESCRIPTION
This adds a code example as proposed in #210 

It also moves the css that _only_ the homepage needs into its own file here, to make it easier to edit without the submodule getting involved

Note this doesn't provide a "Try it" button, which we could. The bernoulli model is the one in the stan-web-demo, but we could also link to https://stan-playground.flatironinstitute.org/?stan=https://raw.githubusercontent.com/stan-dev/cmdstan/develop/examples/bernoulli/bernoulli.stan&data=https://raw.githubusercontent.com/stan-dev/cmdstan/develop/examples/bernoulli/bernoulli.data.json&title=Bernoulli%20Example