### PR TITLE
Add link to AI policy in About section

### DIFF
--- a/about/index.qmd
+++ b/about/index.qmd
@@ -74,7 +74,7 @@ We welcome new Stan contributors!
 
 * Code - If you'd like to contribute code, please consult the
 [Developer Process Wiki](https://github.com/stan-dev/stan/wiki/Developer-process-overview)
-as well as Stan's [AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy)
+as well as Stan's [AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy),
 or check out the GitHub issues on the Stan repositories for the tool that you'd like to contribute to
 and look for issues tagged "good first issue" or "help wanted".
 The GitHub issues as well as the Stan Forums and Stan slack channel are all good places
@@ -179,8 +179,8 @@ form](https://numfocus.org/code-of-conduct).
 ### Software development process
 
 [Stan Developer Wiki](https://github.com/stan-dev/stan/wiki) includes
-links to roadmap, developer process overview, Stan's 
-[AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy)
+links to the roadmap, developer process overview, Stan's 
+[AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy),
 and other useful information about Stan software development process.
 
 ## Acknowledgements

--- a/about/index.qmd
+++ b/about/index.qmd
@@ -74,6 +74,7 @@ We welcome new Stan contributors!
 
 * Code - If you'd like to contribute code, please consult the
 [Developer Process Wiki](https://github.com/stan-dev/stan/wiki/Developer-process-overview)
+as well as Stan's [AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy)
 or check out the GitHub issues on the Stan repositories for the tool that you'd like to contribute to
 and look for issues tagged "good first issue" or "help wanted".
 The GitHub issues as well as the Stan Forums and Stan slack channel are all good places
@@ -178,8 +179,9 @@ form](https://numfocus.org/code-of-conduct).
 ### Software development process
 
 [Stan Developer Wiki](https://github.com/stan-dev/stan/wiki) includes
-links to roadmap, developer process overview, and other useful
-information about Stan software development process.
+links to roadmap, developer process overview, Stan's 
+[AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy)
+and other useful information about Stan software development process.
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Description
This PR includes a link to Stan's AI Contribution Policy (https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy) into the About section of Stan's home page. Stan Dev discussion on AI Policy can be found here [design-docs PR#59](https://github.com/stan-dev/design-docs/pull/59).

The link is added in two places in the About section of the home page: (1) How to Contribute to Stan (user/developer facing) and (2) Stan Governance/Software development process (mainly developer facing)

## TODOs
+ [x] add link to wiki/AI Contribution Policy